### PR TITLE
Update hm_tracking_worker.cpp

### DIFF
--- a/src/hm_tracking_worker.cpp
+++ b/src/hm_tracking_worker.cpp
@@ -14,7 +14,12 @@
  * limitations under the License.
  *****************************************************************************/
 #include "tracking/hm_tracking_worker.hpp"
+
 #include <ros/ros.h>
+#include <string>   // std::string
+#include <vector>   // std::vector
+#include <numeric>  // std::iota
+#include <utility>  // std::make_pair
 #include <Eigen/Core>
 
 #include "common/time.hpp"


### PR DESCRIPTION

error: ‘iota’ is not a member of ‘std’
     std::iota(unassigned_obsvs.begin(), unassigned_obsvs.end(), 0);

